### PR TITLE
feat: 스프링 시큐리티 도입 및 세션 기반 관리자 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/likelion/hongik/controller/AdminController.java
+++ b/src/main/java/com/likelion/hongik/controller/AdminController.java
@@ -12,14 +12,8 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
     private final AdminService adminService;
 
-    @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody LoginRequest request) {
-        boolean isSuccess = adminService.login(request.getLoginId(), request.getPassword());
-
-        if (isSuccess) {
-            return ResponseEntity.ok("로그인 성공");
-        } else {
-            return ResponseEntity.status(401).body("아이디 또는 비밀번호가 틀렸습니다.");
-        }
+    @GetMapping("/login") // 로그인 '페이지'를 보여주는 역할
+    public String loginPage() {
+        return "admin/login"; // src/main/resources/templates/admin/login.html 파일을 찾음
     }
 }

--- a/src/main/java/com/likelion/hongik/domain/Admin.java
+++ b/src/main/java/com/likelion/hongik/domain/Admin.java
@@ -2,13 +2,19 @@ package com.likelion.hongik.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Admin {
+public class Admin implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -20,4 +26,12 @@ public class Admin {
     private String password; // 암호화된 비밀번호
 
     private String name; // 관리자 이름
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_ADMIN"));
+    }
+
+    @Override
+    public String getUsername() { return loginId; }
 }

--- a/src/main/java/com/likelion/hongik/global/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/hongik/global/config/SecurityConfig.java
@@ -1,0 +1,42 @@
+package com.likelion.hongik.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(); // 비밀번호 암호화 객체
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // API 방식이나 테스트 시에는 일단 비활성화
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자 전용 경로
+                        .anyRequest().permitAll() // 나머지는 누구나 접근 가능
+                )
+                .formLogin(form -> form
+                        .loginPage("/admin/login") // 커스텀 로그인 페이지 경로
+                        .loginProcessingUrl("/api/admin/login") // 로그인 처리 URL
+                        .defaultSuccessUrl("/admin/dashboard") // 성공 시 이동
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/admin/logout")
+                        .logoutSuccessUrl("/")
+                        .invalidateHttpSession(true)
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/likelion/hongik/service/AdminDetailService.java
+++ b/src/main/java/com/likelion/hongik/service/AdminDetailService.java
@@ -1,0 +1,22 @@
+package com.likelion.hongik.service;
+
+import com.likelion.hongik.domain.Admin;
+import com.likelion.hongik.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDetailService implements UserDetailsService {
+
+    private final AdminRepository adminRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        return adminRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 아이디의 관리자가 존재하지 않습니다: " + loginId));
+    }
+}

--- a/src/main/java/com/likelion/hongik/service/AdminService.java
+++ b/src/main/java/com/likelion/hongik/service/AdminService.java
@@ -12,9 +12,4 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminService {
     private final AdminRepository adminRepository;
 
-    public boolean login(String loginId, String password) {
-        return adminRepository.findByLoginId(loginId)
-                .map(admin -> admin.getPassword().equals(password)) // 실제 서비스에선 PasswordEncoder 필수
-                .orElse(false);
-    }
 }


### PR DESCRIPTION
- build.gradle에 Spring Security 의존성 추가
- SecurityConfig 설정 (Admin 권한 관리, CSRF 비활성화 등)
- Admin 엔티티에 UserDetails 인터페이스 구현
- AdminDetailService(UserDetailsService) 로직 작성
- 비밀번호 암호화를 위한 BCryptPasswordEncoder 빈 등록
- 기존 커스텀 로그인 로직을 시큐리티 Form Login으로 대체

관련 이슈: #1
<img width="500" height="500" alt="714864ff5ad89e8784df1acd2595a253" src="https://github.com/user-attachments/assets/29baed2d-b948-407f-b3db-1198dc95e88e" />
