### PR TITLE
fix: LoginRequest.java의 필드 이름을 loginId에서 username으로 변경

### DIFF
--- a/src/main/java/com/likelion/hongik/dto/request/LoginRequest.java
+++ b/src/main/java/com/likelion/hongik/dto/request/LoginRequest.java
@@ -1,9 +1,13 @@
 package com.likelion.hongik.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Getter;
 
 @Getter
 public class LoginRequest {
+
+    // "loginId"라는 이름으로 들어와도 username에 드감
+    @JsonAlias("loginId")
     private String username;
     private String password;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 로그인 요청의 내부 필드명이 변경되었습니다(더 명확한 이름으로 리팩토링).
* **Bug Fix / 호환성**
  * 이전 필드명으로 전송된 요청도 계속 정상 처리되도록 호환성 대응이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->