### PR TITLE
[Fix]Enhance form login with custom success and failure handlers

### DIFF
--- a/src/main/java/com/likelion/hongik/global/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/hongik/global/config/SecurityConfig.java
@@ -31,10 +31,16 @@ public class SecurityConfig {
                 .formLogin(form -> form
                     .loginProcessingUrl("/api/admin/login")
                     .successHandler((request, response, authentication) -> {
-                        response.setStatus(HttpServletResponse.SC_OK); // 리다이렉트 대신 200 반환
+                        response.setStatus(HttpServletResponse.SC_OK);
+                        response.setContentType("application/json"); // JSON으로 응답
+                        response.setCharacterEncoding("UTF-8");
+                        response.getWriter().write("{\"message\":\"로그인 성공\"}"); // 리다이렉트 대신 200 반환
                     })
                     .failureHandler((request, response, exception) -> {
-                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 반환
+                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                        response.setContentType("application/json"); // JSON으로 응답
+                        response.setCharacterEncoding("UTF-8");
+                        response.getWriter().write("{\"error\":\"로그인 실패\"}");
                     })
                     .permitAll()
                 )


### PR DESCRIPTION
Updated form login configuration to handle success and failure responses with HTTP status codes.
리다이렉트 경로 대신 코드 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 관리자 로그인 인증 처리 방식 개선: 커스텀 페이지 대신 프로그래밍 방식의 성공/실패 핸들러 적용
  * 인증 성공 시 JSON 응답과 함께 HTTP 200 OK 반환 (예: {"message":"로그인 성공"})
  * 인증 실패 시 JSON 응답과 함께 HTTP 401 Unauthorized 반환 (예: {"error":"로그인 실패"})
  * 기존 API 로그인 엔드포인트("/api/admin/login")는 유지되어 응답 흐름이 더 명확해짐

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->